### PR TITLE
fix: ble mistakenly translated to bgt instead of bge

### DIFF
--- a/src/machine/instruction.cpp
+++ b/src/machine/instruction.cpp
@@ -861,7 +861,7 @@ size_t Instruction::pseudo_from_tokens(
         }
         if (inst.base == QLatin1String("ble")) {
             if (inst.fields.size() != 3) { throw ParseError("number of arguments does not match"); }
-            inst.base = "bgt";
+            inst.base = "bge";
             std::swap(inst.fields[0], inst.fields[1]);
             return code_from_tokens(code, buffsize, inst, reloc, false);
         }


### PR DESCRIPTION
Pseudo instruction 'ble' was mistakenly translated to 'bgt' with swapped parameters. As the 'bgt' is also a pseudo instruction (and translation of pseudo instructions is not recursive), the mistake announced itself by throwing 'unknown instruction' error during compilation of the assembly, where 'ble' was used. Fixed by correcting the translation to 'bge' (already a base instruction) with swapped parameters.