### PR TITLE
GUI: hide main (tab) widget if empty

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -45,6 +45,7 @@ set(gui_SOURCES
         textsignalaction.cpp
         windows/coreview/components/value_handlers.cpp
         windows/coreview/components/cache.cpp
+        widgets/HidingTabWidget.cpp
         )
 set(gui_HEADERS
         dialogs/about/aboutdialog.h
@@ -85,6 +86,7 @@ set(gui_HEADERS
         windows/coreview/data.h
         windows/coreview/components/cache.h
         helper/async_modal.h
+        widgets/HidingTabWidget.h
         )
 set(gui_UI
         dialogs/gotosymbol/gotosymboldialog.ui

--- a/src/gui/mainwindow/mainwindow.h
+++ b/src/gui/mainwindow/mainwindow.h
@@ -8,6 +8,7 @@
 #include "machine/machineconfig.h"
 #include "scene.h"
 #include "ui_MainWindow.h"
+#include "widgets/HidingTabWidget.h"
 #include "windows/cache/cachedock.h"
 #include "windows/csr/csrdock.h"
 #include "windows/editor/srceditor.h"
@@ -116,7 +117,7 @@ private:
     Box<Ui::MainWindow> ui {};
 
     Box<NewDialog> ndialog {};
-    Box<QTabWidget> central_window {};
+    Box<HidingTabWidget> central_window {};
 
     Box<GraphicsView> coreview {};
     Box<CoreViewScene> corescene;

--- a/src/gui/widgets/HidingTabWidget.cpp
+++ b/src/gui/widgets/HidingTabWidget.cpp
@@ -1,0 +1,10 @@
+#include "HidingTabWidget.h"
+
+void HidingTabWidget::tabInserted(int index) {
+    QTabWidget::tabInserted(index);
+    if (count() == 1) { show(); }
+}
+void HidingTabWidget::tabRemoved(int index) {
+    QTabWidget::tabRemoved(index);
+    if (count() == 0) { hide(); }
+}

--- a/src/gui/widgets/HidingTabWidget.h
+++ b/src/gui/widgets/HidingTabWidget.h
@@ -1,0 +1,19 @@
+#ifndef HIDINGTABWIDGET_H
+#define HIDINGTABWIDGET_H
+
+#include <QObject>
+#include <QTabWidget>
+
+/** A widget that hides itself when it has no tabs. */
+class HidingTabWidget : public QTabWidget {
+    Q_OBJECT
+    using Super = QTabWidget;
+
+public:
+    explicit HidingTabWidget(QWidget *parent = nullptr) : Super(parent) {};
+
+    void tabInserted(int index) override;
+    void tabRemoved(int index) override;
+};
+
+#endif // HIDINGTABWIDGET_H


### PR DESCRIPTION
Allows the user to hide core view completely when they want to focus on other parts. Also hides tab bar if only one tab is present.

Resolves #61 