### PR TITLE
Disable rich text pasting

### DIFF
--- a/src/gui/windows/editor/srceditor.cpp
+++ b/src/gui/windows/editor/srceditor.cpp
@@ -284,3 +284,7 @@ void SrcEditor::setShowLineNumbers(bool show) {
 void SrcEditor::insertFromMimeData(const QMimeData *source) {
     if (source->hasText()) { insertPlainText(source->text()); }
 }
+
+bool SrcEditor::canInsertFromMimeData(const QMimeData *source) const {
+    return source->hasText();
+}

--- a/src/gui/windows/editor/srceditor.cpp
+++ b/src/gui/windows/editor/srceditor.cpp
@@ -267,6 +267,7 @@ void SrcEditor::updateLineNumberArea(const QRect &rect, int dy) {
 
     if (rect.contains(viewport()->rect())) updateMargins(0);
 }
+
 void SrcEditor::resizeEvent(QResizeEvent *event) {
     QPlainTextEdit::resizeEvent(event);
 
@@ -274,7 +275,12 @@ void SrcEditor::resizeEvent(QResizeEvent *event) {
     line_number_area->setGeometry(
         QRect(cr.left(), cr.top(), line_number_area->sizeHint().width(), cr.height()));
 }
+
 void SrcEditor::setShowLineNumbers(bool show) {
     line_number_area->set(show);
     updateMargins(0);
+}
+
+void SrcEditor::insertFromMimeData(const QMimeData *source) {
+    if (source->hasText()) { insertPlainText(source->text()); }
 }

--- a/src/gui/windows/editor/srceditor.h
+++ b/src/gui/windows/editor/srceditor.h
@@ -5,6 +5,7 @@
 #include "linenumberarea.h"
 #include "machine/machine.h"
 
+#include <QMimeData>
 #include <QString>
 #include <QSyntaxHighlighter>
 #include <QTextEdit>
@@ -33,6 +34,7 @@ public:
 protected:
     void keyPressEvent(QKeyEvent *event) override;
     void resizeEvent(QResizeEvent *event) override;
+    void insertFromMimeData(const QMimeData *source) override;
 
 signals:
     void file_name_change();

--- a/src/gui/windows/editor/srceditor.h
+++ b/src/gui/windows/editor/srceditor.h
@@ -5,10 +5,10 @@
 #include "linenumberarea.h"
 #include "machine/machine.h"
 
-#include <QMimeData>
 #include <QString>
 #include <QSyntaxHighlighter>
 #include <QTextEdit>
+#include <QMimeData>
 #include <qplaintextedit.h>
 #include <qwidget.h>
 
@@ -35,6 +35,7 @@ protected:
     void keyPressEvent(QKeyEvent *event) override;
     void resizeEvent(QResizeEvent *event) override;
     void insertFromMimeData(const QMimeData *source) override;
+    bool canInsertFromMimeData(const QMimeData *source) const override;
 
 signals:
     void file_name_change();


### PR DESCRIPTION
Before, it was possible to paste rich text, e.g. from a browser, which messed up the font, color, line height, etc. of the editor.
This PR changes this behavior so that only the plain text gets copied.