### PR TITLE
CLI: reporter dump to json

### DIFF
--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -51,6 +51,7 @@ void create_parser(QCommandLineParser &p) {
                   "Print general purpose register changes. You can use * for "
                   "all registers.",
                   "REG" });
+    p.addOption({ "dump-to-json", "Configure reportor dump to json file.", "FNAME" });
     p.addOption({ { "dump-registers", "d-regs" }, "Dump registers state at program exit." });
     p.addOption({ "dump-cache-stats", "Dump cache statistics at program exit." });
     p.addOption({ "dump-cycles", "Dump number of CPU cycles till program end." });
@@ -286,6 +287,10 @@ void configure_tracer(QCommandLineParser &p, Tracer &tr) {
 }
 
 void configure_reporter(QCommandLineParser &p, Reporter &r, const SymbolTable *symtab) {
+    if (p.isSet("dump-to-json")) {
+        r.dump_format = (DumpFormat)(r.dump_format | DumpFormat::JSON);
+        r.dump_file_json = p.value("dump-to-json");
+    }
     if (p.isSet("dump-registers")) { r.enable_regs_reporting(); }
     if (p.isSet("dump-cache-stats")) { r.enable_cache_stats(); }
     if (p.isSet("dump-cycles")) { r.enable_cycles_reporting(); }

--- a/src/cli/reporter.cpp
+++ b/src/cli/reporter.cpp
@@ -149,7 +149,7 @@ void Reporter::report_gp_reg(unsigned int i, bool last) {
         dump_data_json["regs"] = regs;
     }
     if (dump_format & DumpFormat::CONSOLE) {
-        printf("%s: %s%s", qPrintable(key), qPrintable(value), (last) ? "\n" : " ");
+        printf("%s:%s%s", qPrintable(key), qPrintable(value), (last) ? "\n" : " ");
     }
 }
 
@@ -168,7 +168,7 @@ void Reporter::report_csr_reg(size_t internal_id, bool last) {
 }
 
 void Reporter::report_caches() {
-    dump_data_json["caches"] = {};
+    if (dump_format & DumpFormat::JSON) { dump_data_json["caches"] = {}; }
     printf("Cache statistics report:\n");
     report_cache("i-cache", *machine->cache_program());
     report_cache("d-cache", *machine->cache_data());

--- a/src/cli/reporter.cpp
+++ b/src/cli/reporter.cpp
@@ -89,16 +89,39 @@ void Reporter::report() {
     if (e_regs) { report_regs(); }
     if (e_cache_stats) { report_caches(); }
     if (e_cycles) {
-        printf("cycles: %" PRIu32 "\n", machine->core()->get_cycle_count());
-        printf("stalls: %" PRIu32 "\n", machine->core()->get_stall_count());
+        QString cycle_count = QString::asprintf("%" PRIu32, machine->core()->get_cycle_count());
+        QString stall_count = QString::asprintf("%" PRIu32, machine->core()->get_stall_count());
+        if (dump_format & DumpFormat::JSON) {
+            QJsonObject temp = {};
+            temp["cycles"] = cycle_count;
+            temp["stalls"] = stall_count;
+            dump_data_json["cycles"] = temp;
+        }
+        if (dump_format & DumpFormat::CONSOLE) {
+            printf("cycles: %s\n", qPrintable(cycle_count));
+            printf("stalls: %s\n", qPrintable(stall_count));
+        }
     }
     for (const DumpRange &range : dump_ranges) {
         report_range(range);
     }
+
+    if (dump_format & DumpFormat::JSON) {
+        QFile file(dump_file_json);
+        QByteArray bytes = QJsonDocument(dump_data_json).toJson(QJsonDocument::Indented);
+        if (file.open(QIODevice::WriteOnly)) {
+            file.write(bytes);
+            file.close();
+            printf("JSON object written to file");
+        } else {
+            printf("Could not open file for writing");
+        }
+    }
 }
 
-void Reporter::report_regs() const {
-    printf("PC:0x%08" PRIx64 "\n", machine->registers()->read_pc().get_raw());
+void Reporter::report_regs() {
+    dump_data_json["regs"] = {};
+    report_pc();
     for (unsigned i = 0; i < REGISTER_COUNT; i++) {
         report_gp_reg(i, (i == REGISTER_COUNT - 1));
     }
@@ -107,18 +130,45 @@ void Reporter::report_regs() const {
     }
 }
 
-void Reporter::report_gp_reg(unsigned int i, bool last) const {
-    printf(
-        "R%u:0x%08" PRIx64 "%s", i, machine->registers()->read_gp(i).as_u64(), (last) ? "\n" : " ");
+void Reporter::report_pc() {
+    QString value = QString::asprintf("0x%08" PRIx64, machine->registers()->read_pc().get_raw());
+    if (dump_format & DumpFormat::JSON) {
+        QJsonObject regs = dump_data_json["regs"].toObject();
+        regs["PC"] = value;
+        dump_data_json["regs"] = regs;
+    }
+    if (dump_format & DumpFormat::CONSOLE) { printf("PC:%s\n", qPrintable(value)); }
 }
 
-void Reporter::report_csr_reg(size_t internal_id, bool last) const {
-    printf(
-        "%s: 0x%08" PRIx64 "%s", CSR::REGISTERS[internal_id].name,
-        machine->control_state()->read_internal(internal_id).as_u64(), (last) ? "\n" : " ");
+void Reporter::report_gp_reg(unsigned int i, bool last) {
+    QString key = QString::asprintf("R%u", i);
+    QString value = QString::asprintf("0x%08" PRIx64, machine->registers()->read_gp(i).as_u64());
+    if (dump_format & DumpFormat::JSON) {
+        QJsonObject regs = dump_data_json["regs"].toObject();
+        regs[key] = value;
+        dump_data_json["regs"] = regs;
+    }
+    if (dump_format & DumpFormat::CONSOLE) {
+        printf("%s:%s%s", qPrintable(key), qPrintable(value), (last) ? "\n" : " ");
+    }
 }
 
-void Reporter::report_caches() const {
+void Reporter::report_csr_reg(size_t internal_id, bool last) {
+    QString key = QString::asprintf("%s", CSR::REGISTERS[internal_id].name);
+    QString value = QString::asprintf(
+        "0x%08" PRIx64, machine->control_state()->read_internal(internal_id).as_u64());
+    if (dump_format & DumpFormat::JSON) {
+        QJsonObject regs = dump_data_json["regs"].toObject();
+        regs[key] = value;
+        dump_data_json["regs"] = regs;
+    }
+    if (dump_format & DumpFormat::CONSOLE) {
+        printf("%s:%s%s", qPrintable(key), qPrintable(value), (last) ? "\n" : " ");
+    }
+}
+
+void Reporter::report_caches() {
+    dump_data_json["caches"] = {};
     printf("Cache statistics report:\n");
     report_cache("i-cache", *machine->cache_program());
     report_cache("d-cache", *machine->cache_data());
@@ -128,15 +178,29 @@ void Reporter::report_caches() const {
 }
 
 void Reporter::report_cache(const char *cache_name, const Cache &cache) {
-    printf("%s:reads: %" PRIu32 "\n", cache_name, cache.get_read_count());
-    printf("%s:hit: %" PRIu32 "\n", cache_name, cache.get_hit_count());
-    printf("%s:miss: %" PRIu32 "\n", cache_name, cache.get_miss_count());
-    printf("%s:hit-rate: %.3lf\n", cache_name, cache.get_hit_rate());
-    printf("%s:stalled-cycles: %" PRIu32 "\n", cache_name, cache.get_stall_count());
-    printf("%s:improved-speed: %.3lf\n", cache_name, cache.get_speed_improvement());
+    if (dump_format & DumpFormat::JSON) {
+        QJsonObject caches = dump_data_json["caches"].toObject();
+        QJsonObject temp = {};
+        temp["reads"] = QString::asprintf("%" PRIu32, cache.get_read_count());
+        temp["hit"] = QString::asprintf("%" PRIu32, cache.get_hit_count());
+        temp["miss"] = QString::asprintf("%" PRIu32, cache.get_miss_count());
+        temp["hit_rate"] = QString::asprintf("%.3lf", cache.get_hit_rate());
+        temp["stalled_cycles"] = QString::asprintf("%" PRIu32, cache.get_stall_count());
+        temp["improved_speed"] = QString::asprintf("%.3lf", cache.get_speed_improvement());
+        caches[cache_name] = temp;
+        dump_data_json["caches"] = caches;
+    }
+    if (dump_format & DumpFormat::CONSOLE) {
+        printf("%s:reads: %" PRIu32 "\n", cache_name, cache.get_read_count());
+        printf("%s:hit: %" PRIu32 "\n", cache_name, cache.get_hit_count());
+        printf("%s:miss: %" PRIu32 "\n", cache_name, cache.get_miss_count());
+        printf("%s:hit-rate: %.3lf\n", cache_name, cache.get_hit_rate());
+        printf("%s:stalled-cycles: %" PRIu32 "\n", cache_name, cache.get_stall_count());
+        printf("%s:improved-speed: %.3lf\n", cache_name, cache.get_speed_improvement());
+    }
 }
 
-void Reporter::report_range(const Reporter::DumpRange &range) const {
+void Reporter::report_range(const Reporter::DumpRange &range) {
     FILE *out = fopen(range.path_to_write.toLocal8Bit().data(), "w");
     if (out == nullptr) {
         fprintf(

--- a/src/cli/reporter.cpp
+++ b/src/cli/reporter.cpp
@@ -120,7 +120,7 @@ void Reporter::report() {
 }
 
 void Reporter::report_regs() {
-    dump_data_json["regs"] = {};
+    if (dump_format & DumpFormat::JSON) { dump_data_json["regs"] = {}; }
     report_pc();
     for (unsigned i = 0; i < REGISTER_COUNT; i++) {
         report_gp_reg(i, (i == REGISTER_COUNT - 1));
@@ -149,7 +149,7 @@ void Reporter::report_gp_reg(unsigned int i, bool last) {
         dump_data_json["regs"] = regs;
     }
     if (dump_format & DumpFormat::CONSOLE) {
-        printf("%s:%s%s", qPrintable(key), qPrintable(value), (last) ? "\n" : " ");
+        printf("%s: %s%s", qPrintable(key), qPrintable(value), (last) ? "\n" : " ");
     }
 }
 
@@ -163,7 +163,7 @@ void Reporter::report_csr_reg(size_t internal_id, bool last) {
         dump_data_json["regs"] = regs;
     }
     if (dump_format & DumpFormat::CONSOLE) {
-        printf("%s:%s%s", qPrintable(key), qPrintable(value), (last) ? "\n" : " ");
+        printf("%s: %s%s", qPrintable(key), qPrintable(value), (last) ? "\n" : " ");
     }
 }
 

--- a/src/cli/reporter.h
+++ b/src/cli/reporter.h
@@ -15,7 +15,7 @@ using machine::Address;
 
 enum DumpFormat {
     CONSOLE = 1 << 0,
-    JSON = 2 << 0,
+    JSON = 1 << 1,
 };
 
 /**

--- a/src/cli/reporter.h
+++ b/src/cli/reporter.h
@@ -5,11 +5,18 @@
 #include "machine/machine.h"
 
 #include <QCoreApplication>
+#include <QFile>
+#include <QJsonDocument>
+#include <QJsonObject>
 #include <QObject>
 #include <QString>
-#include <QVector>
 
 using machine::Address;
+
+enum DumpFormat {
+    CONSOLE = 1 << 0,
+    JSON = 2 << 0,
+};
 
 /**
  * Watches for special events in the machine (e.g. stop, exception, trap) and prints related
@@ -59,12 +66,18 @@ private:
     FailReason e_fail = FR_NONE;
 
     void report();
-    void report_regs() const;
-    void report_caches() const;
-    void report_range(const DumpRange &range) const;
-    void report_csr_reg(size_t internal_id, bool last) const;
-    void report_gp_reg(unsigned int i, bool last) const;
-    static void report_cache(const char *cache_name, const machine::Cache &cache);
+    void report_pc();
+    void report_regs();
+    void report_caches();
+    void report_range(const DumpRange &range);
+    void report_csr_reg(size_t internal_id, bool last);
+    void report_gp_reg(unsigned int i, bool last);
+    void report_cache(const char *cache_name, const machine::Cache &cache);
+
+public:
+    DumpFormat dump_format = DumpFormat::CONSOLE;
+    QString dump_file_json;
+    QJsonObject dump_data_json = {};
 };
 
 #endif // REPORTER_H


### PR DESCRIPTION
trying to close #99 

- New cli option: `--dump-to-json <FNAME>`
- New enum: 
	```cpp
	enum DumpFormat {
	    CONSOLE = 1 << 0,
	    JSON = 1 << 1,
	};
	```
- New public member(Reporter): 
	```cpp
	public:
	    DumpFormat dump_format = DumpFormat::CONSOLE; // which format dump
	    QString dump_file_json;                       // where to dump
	    QJsonObject dump_data_json = {};              // keep data

	```
- Output example:
	```json
	{
	    "caches": {
	        "d-cache": {
	            "hit": "0",
	            "hit_rate": "0.000",
	            "improved_speed": "100.000",
	            "miss": "0",
	            "reads": "2",
	            "stalled_cycles": "36"
	        },
	        "i-cache": {
	            "hit": "0",
	            "hit_rate": "0.000",
	            "improved_speed": "100.000",
	            "miss": "0",
	            "reads": "9",
	            "stalled_cycles": "81"
	        }
	    },
	    "cycles": {
	        "cycles": "9",
	        "stalls": "0"
	    },
	    "regs": {
	        "PC": "0x00000004",
	        "R0": "0x00000000",
	        "R1": "0x00000000",
	        "R10": "0x00000000",
	        "R11": "0x00000000",
	        "R12": "0x00000000",
	        "R13": "0x00000000",
	        "R14": "0x00000000",
	        "R15": "0x00000000",
	        "R16": "0x00000000",
	        "R17": "0x00000000",
	        "R18": "0x00000000",
	        "R19": "0x00000000",
	        "R2": "0x00000000",
	        "R20": "0x00000000",
	        "R21": "0x00000000",
	        "R22": "0x00000000",
	        "R23": "0x00000000",
	        "R24": "0x00000000",
	        "R25": "0x00000000",
	        "R26": "0x00000000",
	        "R27": "0x00000000",
	        "R28": "0x00000000",
	        "R29": "0x00000000",
	        "R3": "0x00000000",
	        "R30": "0x00000000",
	        "R31": "0x00000000",
	        "R4": "0x0000bf24",
	        "R5": "0x00005678",
	        "R6": "0x000068ac",
	        "R7": "0x00000000",
	        "R8": "0x00000000",
	        "R9": "0x00000000",
	        "cycle": "0x00000009",
	        "marchid": "0x00000000",
	        "mcause": "0x00000000",
	        "mcycle": "0x00000009",
	        "mepc": "0x00000000",
	        "mhardid": "0x00000000",
	        "mie": "0x00000000",
	        "mimpid": "0x00000000",
	        "minstret": "0x00000008",
	        "mip": "0x00000000",
	        "misa": "0x40001111",
	        "mscratch": "0x00000000",
	        "mstatus": "0x00000000",
	        "mtinst": "0x00000000",
	        "mtval": "0x00000000",
	        "mtval2": "0x00000000",
	        "mtvec": "0x00000000",
	        "mvendorid": "0x00000000"
	    }
	}
	```