### PR TITLE
Machine: fix instruction tokenized for inst.xxx

### DIFF
--- a/src/machine/instruction.cpp
+++ b/src/machine/instruction.cpp
@@ -1488,7 +1488,7 @@ TokenizedInstruction TokenizedInstruction::from_line(
     }
     end = start;
     while (end < line_str.size()) {
-        if (!line_str.at(end).isLetterOrNumber()) { break; }
+        if (line_str.at(end).isSpace()) { break; }
         end++;
     }
     QString inst_base = line_str.mid(start, end - start).toLower();


### PR DESCRIPTION
This causes “. “ not being handled correctly, e.g. ‘lr.w ’ ends up being parsed as 

inst_base => `lr`.
inst_fields => [“w”]

![image](https://github.com/cvut/qtrvsim/assets/69898423/cf9480c6-74d8-41fb-867e-e74289967557)
