### PR TITLE
Machine: fix instruction to_str

### DIFF
--- a/src/common/string_utils.h
+++ b/src/common/string_utils.h
@@ -6,7 +6,11 @@
 namespace str {
 template<typename T>
 QString asHex(T number) {
-    return QString("0x%1").arg(number, 0, 16);
+    if (number < 0) {
+        return QString::asprintf("-0x%x", -number);
+    } else {
+        return QString::asprintf("0x%x", number);
+    }
 }
 } // namespace str
 


### PR DESCRIPTION
negative hex should use '-' in the str, or it will be treated as uint

`jal x1, -0xFF`:

```c
str::asHex((int32_t)-0xff) -> s: 0xffffffffffffff01
str::asHex((uint32_t)-0xff) -> s: 0xffffff01
```

'-' lost after to_str()