### PR TITLE
Add 25x speed for teaching convenience

### DIFF
--- a/src/gui/mainwindow/MainWindow.ui
+++ b/src/gui/mainwindow/MainWindow.ui
@@ -108,6 +108,7 @@
     <addaction name="ips2"/>
     <addaction name="ips5"/>
     <addaction name="ips10"/>
+    <addaction name="ips25"/>
     <addaction name="ipsUnlimited"/>
     <addaction name="ipsMax"/>
     <addaction name="separator"/>
@@ -164,6 +165,7 @@
    <addaction name="ips2"/>
    <addaction name="ips5"/>
    <addaction name="ips10"/>
+   <addaction name="ips25"/>
    <addaction name="ipsUnlimited"/>
    <addaction name="ipsMax"/>
    <addaction name="actionNew"/>
@@ -403,6 +405,23 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+0</string>
+   </property>
+  </action>
+  <action name="ips25">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>2&amp;5 instructions per second</string>
+   </property>
+   <property name="iconText">
+    <string>25x</string>
+   </property>
+   <property name="toolTip">
+    <string>Run CPU in speed of 25 instructions per second</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+F5</string>
    </property>
   </action>
   <action name="ipsUnlimited">

--- a/src/gui/mainwindow/mainwindow.cpp
+++ b/src/gui/mainwindow/mainwindow.cpp
@@ -131,6 +131,7 @@ MainWindow::MainWindow(QSettings *settings, QWidget *parent)
     speed_group->addAction(ui->ips2);
     speed_group->addAction(ui->ips5);
     speed_group->addAction(ui->ips10);
+    speed_group->addAction(ui->ips25);
     speed_group->addAction(ui->ipsUnlimited);
     speed_group->addAction(ui->ipsMax);
     ui->ips1->setChecked(true);
@@ -166,6 +167,7 @@ MainWindow::MainWindow(QSettings *settings, QWidget *parent)
     connect(ui->ips2, &QAction::toggled, this, &MainWindow::set_speed);
     connect(ui->ips5, &QAction::toggled, this, &MainWindow::set_speed);
     connect(ui->ips10, &QAction::toggled, this, &MainWindow::set_speed);
+    connect(ui->ips25, &QAction::toggled, this, &MainWindow::set_speed);
     connect(ui->ipsUnlimited, &QAction::toggled, this, &MainWindow::set_speed);
     connect(ui->ipsMax, &QAction::toggled, this, &MainWindow::set_speed);
 
@@ -481,6 +483,8 @@ void MainWindow::set_speed() {
         machine->set_speed(200);
     } else if (ui->ips10->isChecked()) {
         machine->set_speed(100);
+    } else if (ui->ips25->isChecked()) {
+        machine->set_speed(40);
     } else if (ui->ipsMax->isChecked()) {
         machine->set_speed(0, 100);
     } else {


### PR DESCRIPTION
To meet the requirements of the issue #119  , add a 25x option for the speed adjustment of executing commands, and set Ctrl+F5 as the shortcut key. The effect should be as follows:

- 25x option for speed adjustment is available.
- Ctrl+F5 acts as the shortcut key for this speed adjustment.

The effect is as follows:
[effect.webm](https://github.com/cvut/qtrvsim/assets/98281165/004a4a2b-0228-48d5-aece-d89044523697)
