### PR TITLE
Add Not Most Recently Used Cache replacement policy

### DIFF
--- a/src/gui/dialogs/new/NewDialogCache.ui
+++ b/src/gui/dialogs/new/NewDialogCache.ui
@@ -97,6 +97,11 @@
           <string>Pseudo Least Recently Used (PLRU)</string>
          </property>
         </item>
+        <item>
+         <property name="text">
+          <string>Not Most Recently Used (NMRU)</string>
+         </property>
+        </item>
        </widget>
       </item>
       <item row="4" column="0">

--- a/src/machine/machineconfig.h
+++ b/src/machine/machineconfig.h
@@ -45,7 +45,8 @@ public:
         RP_RAND, // Random
         RP_LRU,  // Least recently used
         RP_LFU,  // Least frequently used
-        RP_PLRU  // Pseudo Least recently used
+        RP_PLRU, // Pseudo Least recently used
+        RP_NMRU  // Not most recently used
     };
 
     enum WritePolicy {

--- a/src/machine/memory/cache/cache.test.cpp
+++ b/src/machine/memory/cache/cache.test.cpp
@@ -34,8 +34,8 @@ constexpr array<uint64_t, 1> values { 0x4142434445464748 };
  * Cache configuration parameters for testing
  * (all combinations are tested)
  */
-constexpr array<CacheConfig::ReplacementPolicy, 4> replacement_policies {
-    CacheConfig::RP_RAND, CacheConfig::RP_LFU, CacheConfig::RP_LRU, CacheConfig::RP_PLRU
+constexpr array<CacheConfig::ReplacementPolicy, 5> replacement_policies {
+    CacheConfig::RP_RAND, CacheConfig::RP_LFU, CacheConfig::RP_LRU, CacheConfig::RP_PLRU, CacheConfig::RP_NMRU
 };
 constexpr array<CacheConfig::WritePolicy, 3> write_policies {
     CacheConfig::WP_THROUGH_NOALLOC, // THIS
@@ -242,7 +242,7 @@ void TestCache::cache_correctness() {
     //            stderr, "{ %d, %d }, ", cache.get_hit_count(),
     //            cache.get_miss_count());
 
-    if (cache_config.replacement_policy() != CacheConfig::RP_RAND) {
+    if ((cache_config.replacement_policy() != CacheConfig::RP_RAND) && (cache_config.replacement_policy() != CacheConfig::RP_NMRU)) {
         // Performance of random policy is implementation dependant and
         // meaningless.
         QCOMPARE(performance, cache_test_performance_data.at(case_number));

--- a/src/machine/memory/cache/cache_policy.h
+++ b/src/machine/memory/cache/cache_policy.h
@@ -129,6 +129,32 @@ private:
     const size_t associativityCLog2;
 };
 
+/**
+ * Not Most Recently Used
+ *
+ * Select Randomly from Not Most
+ * Recently Used Blocks
+ */
+class CachePolicyNMRU final : public CachePolicy {
+public:
+    /**
+     * @param associativity     degree of assiciaivity
+     * @param set_count         number of blocks / rows in a way (or sets in
+     * cache)
+     */
+    CachePolicyNMRU(size_t associativity, size_t set_count);
+
+    [[nodiscard]] size_t select_way_to_evict(size_t row) const final;
+
+    void update_stats(size_t way, size_t row, bool is_valid) final;
+
+private:
+    /**
+     * Pointer to Most Recently Used Block
+     */
+    std::vector<uint32_t> mru_ptr;
+    const size_t associativity;
+};
 } // namespace machine
 
 #endif // CACHE_POLICY_H


### PR DESCRIPTION
Just another cache policy commonly used. Choose randomly from blocks that are not most recently used.