### PR TITLE
Machine: fix CSR::RegisterMapByName key type to std::string

### DIFF
--- a/src/machine/csr/controlstate.h
+++ b/src/machine/csr/controlstate.h
@@ -255,16 +255,16 @@ namespace machine { namespace CSR {
 
     class RegisterMapByName {
         bool initialized = false;
-        std::unordered_map<const char *, size_t> map;
+        std::unordered_map<std::string, size_t> map;
 
         void init() {
             for (size_t i = 0; i < REGISTERS.size(); i++) {
-                map.emplace(REGISTERS[i].name, i);
+                map.emplace(std::string(REGISTERS[i].name), i);
             }
             initialized = true;
         }
     public:
-        size_t at(const char* name) {
+        size_t at(std::string name) {
             if (!initialized) init();
             return map.at(name);
         }

--- a/src/machine/instruction.cpp
+++ b/src/machine/instruction.cpp
@@ -1375,14 +1375,15 @@ bool parse_immediate_value(
 
 uint16_t parse_csr_address(const QString &field_token, uint &chars_taken) {
     if (field_token.at(0).isLetter()) {
-        size_t index = CSR::REGISTER_MAP_BY_NAME.at(qPrintable(field_token));
-        if (index < 0) {
+        try {
+            size_t index = CSR::REGISTER_MAP_BY_NAME.at(field_token.toStdString());
+            auto &reg = CSR::REGISTERS[index];
+            chars_taken = strlen(reg.name);
+            return reg.address.data;
+        } catch (std::out_of_range &e) {
             chars_taken = 0;
             return 0;
         }
-        auto &reg = CSR::REGISTERS[index];
-        chars_taken = strlen(reg.name);
-        return reg.address.data;
     } else {
         char *r;
         uint64_t val;


### PR DESCRIPTION
Sorry, this is a bug caused by #133 

Before the #133 merge, the key I used was QString, but it didn't work on Windows

So I solved the problem with const chat*, but didn't test it (my fault).

When I did #120, it didn't match anything, so there was this PR