### PR TITLE
extend Memory backend to dealing with various needs

### DIFF
--- a/src/gui/ui/hexlineedit.cpp
+++ b/src/gui/ui/hexlineedit.cpp
@@ -48,7 +48,7 @@ HexLineEdit::HexLineEdit(
     set_value(0);
 }
 
-void HexLineEdit::set_value(uint32_t value) {
+void HexLineEdit::set_value(uint64_t value) {
     QString s, t = "";
     last_set = value;
     s = QString::number(value, base);
@@ -60,8 +60,8 @@ void HexLineEdit::set_value(uint32_t value) {
 
 void HexLineEdit::on_edit_finished() {
     bool ok;
-    uint32_t val;
-    val = text().toULong(&ok, 16);
+    uint64_t val;
+    val = text().toULongLong(&ok, 16);
     if (!ok) {
         set_value(last_set);
         return;

--- a/src/gui/ui/hexlineedit.h
+++ b/src/gui/ui/hexlineedit.h
@@ -17,10 +17,10 @@ public:
         const QString &prefix = "0x");
 
 public slots:
-    void set_value(uint32_t value);
+    void set_value(uint64_t value);
 
 signals:
-    void value_edit_finished(uint32_t value);
+    void value_edit_finished(uint64_t value);
 
 private slots:
     void on_edit_finished();

--- a/src/gui/windows/memory/memorydock.cpp
+++ b/src/gui/windows/memory/memorydock.cpp
@@ -32,7 +32,7 @@ MemoryDock::MemoryDock(QWidget *parent, QSettings *settings) : Super(parent) {
     memory_content->verticalHeader()->hide();
     // memory_content->setHorizontalHeader(memory_model->);
 
-    auto *go_edit = new HexLineEdit(nullptr, 8, 16, "0x");
+    auto *go_edit = new HexLineEdit(nullptr, 16, 16, "0x");
 
     auto *layout_top = new QHBoxLayout;
     layout_top->addWidget(cell_size);
@@ -57,7 +57,7 @@ MemoryDock::MemoryDock(QWidget *parent, QSettings *settings) : Super(parent) {
         memory_model, &MemoryModel::cached_access);
     connect(
         go_edit, &HexLineEdit::value_edit_finished, memory_content,
-        [memory_content](uint32_t value) {
+        [memory_content](uint64_t value) {
             memory_content->go_to_address(machine::Address(value));
         });
     connect(

--- a/src/machine/memory/backend/memory.h
+++ b/src/machine/memory/backend/memory.h
@@ -78,6 +78,7 @@ public:
     // This is dummy constructor for qt internal uses only.
     Memory();
     explicit Memory(Endian simulated_machine_endian);
+    Memory(Endian simulated_machine_endian, size_t xlen);
     Memory(const Memory &);
     ~Memory() override;
     void reset(); // Reset whole content of memory (removes old tree and creates
@@ -109,14 +110,16 @@ public:
 private:
     union MemoryTree *mt_root;
     uint32_t change_counter = 0;
+    size_t xlen;
     static union MemoryTree *allocate_section_tree();
-    static void free_section_tree(union MemoryTree *, size_t depth);
+    static void free_section_tree(union MemoryTree *, size_t depth , size_t memory_tree_depth);
     static bool compare_section_tree(
         const union MemoryTree *,
         const union MemoryTree *,
-        size_t depth);
+        size_t depth,
+        size_t memory_tree_depth);
     static union MemoryTree *
-    copy_section_tree(const union MemoryTree *, size_t depth);
+    copy_section_tree(const union MemoryTree *, size_t depth , size_t memory_tree_depth);
     [[nodiscard]] uint32_t get_change_counter() const;
 };
 } // namespace machine


### PR DESCRIPTION
We know that qtrvsim uses a memorytree with a fixed depth of 6, which causes its memory model to only accept 32-bit memory access instructions, thus restricting 64-bit access. This limitation presents an issue in terms of educational rigor. Therefore, this PR makes corresponding adjustments so that the memory class adapts its memory access bit width according to xlen, while also addressing the #146 