### PR TITLE
Fix heap overflow during exception handling

### DIFF
--- a/src/machine/simulator_exception.cpp
+++ b/src/machine/simulator_exception.cpp
@@ -19,9 +19,9 @@ SimulatorException::SimulatorException(
 }
 
 const char *SimulatorException::what() const noexcept {
-    QString message = this->msg(true);
+    std::string message = this->msg(true).toStdString();
     char *cstr = new char[message.length() + 1];
-    std::strcpy(cstr, message.toStdString().c_str());
+    std::strcpy(cstr, message.c_str());
     return cstr;
 }
 

--- a/src/machine/simulator_exception.cpp
+++ b/src/machine/simulator_exception.cpp
@@ -16,13 +16,25 @@ SimulatorException::SimulatorException(
     this->ext = std::move(ext);
     this->file = std::move(file);
     this->line = line;
+    this->cached_what = nullptr;
+}
+
+SimulatorException::~SimulatorException() {
+    if (this->cached_what) {
+        delete[] this->cached_what;
+    }
 }
 
 const char *SimulatorException::what() const noexcept {
+    if (this->cached_what) {
+        return this->cached_what;
+    }
+
     std::string message = this->msg(true).toStdString();
-    char *cstr = new char[message.length() + 1];
-    std::strcpy(cstr, message.c_str());
-    return cstr;
+    this->cached_what = new char[message.length() + 1];
+    std::strcpy(this->cached_what, message.c_str());
+
+    return this->cached_what;
 }
 
 QString SimulatorException::msg(bool pos) const {

--- a/src/machine/simulator_exception.h
+++ b/src/machine/simulator_exception.h
@@ -10,12 +10,15 @@ namespace machine {
 class SimulatorException : public std::exception {
 public:
     SimulatorException(QString reason, QString ext, QString file, int line);
+    ~SimulatorException();
     const char *what() const noexcept override;
     QString msg(bool pos) const;
 
 protected:
     QString name, reason, ext, file;
     int line;
+private:
+    mutable char * cached_what;
 };
 
 /* This is list of all QtRvSim specific exceptions


### PR DESCRIPTION
First commit: Fixes a heap overflow that occurs when `msg` of `SimulatorException` contains multi-byte characters.

Second commit: Makes `SimulatorException` free the memory allocated by `what()` on destruction.