### PR TITLE
CI: Bump dependencies

### DIFF
--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -276,7 +276,7 @@ jobs:
 
       - name: Store created artifacts
         # Use of tar significantly improves performance as artifact upload has significant per file penalty
-        uses: alehechka/upload-tartifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: riscv-official-tests
           path: tests/riscv-official/isa

--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -123,7 +123,7 @@ jobs:
 
       - name: Get official RISC-V tests
         if: ${{ steps.cache-tests.outputs.cache-hit != 'true' }}
-        uses: alehechka/download-tartifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: riscv-official-tests
 

--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -69,13 +69,13 @@ jobs:
       - run: git submodule update --recursive --init
 
       - name: Ccache
-        uses: hendrikmuhs/ccache-action@v1.2.11 # https://github.com/hendrikmuhs/ccache-action/issues/181
+        uses: hendrikmuhs/ccache-action@v1
         with:
           key: ${{ github.ref_name }}-${{ matrix.config.name }}
 
       - name: Install specified Qt version
         if: matrix.config.qt_version != 'native'
-        uses: jurplel/install-qt-action@v3
+        uses: jurplel/install-qt-action@v4
         with:
           version: ${{ matrix.config.qt_version }}
           cache: true
@@ -89,7 +89,7 @@ jobs:
 
       -  name: Setup Ninja
          if: matrix.config.build_system == 'Ninja'
-         uses: seanmiddleditch/gha-setup-ninja@v4
+         uses: seanmiddleditch/gha-setup-ninja@v6
 
       - name: Create Build Environment
         run: cmake -E make_directory ${{ github.workspace }}/build

--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -126,6 +126,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: riscv-official-tests
+          path: tests/riscv-official/isa
 
       - name: Official RISC-V tests (single cycle)
         # The testing python script does not support Ubuntu 18


### PR DESCRIPTION
Remove deprecated action and use the native one. The original performance issue seems to be fixed now.