### PR TITLE
GUI: Fix compiliation with Qt 6.10

### DIFF
--- a/src/gui/windows/coreview/components/value_handlers.cpp
+++ b/src/gui/windows/coreview/components/value_handlers.cpp
@@ -50,7 +50,7 @@ RegIdValue::RegIdValue(svgscene::SimpleTextItem *element, const machine::Registe
     , data(data) {}
 
 void RegIdValue::update() {
-    element->setText(QString("%1").arg(data, 2, 10, QChar('0')));
+    element->setText(QString("%1").arg(int(data), 2, 10, QChar('0')));
 }
 
 DebugValue::DebugValue(SimpleTextItem *element, const unsigned int &data)


### PR DESCRIPTION
Gentoo's CI reported a compilation issue with Qt 6.10 [1]: the type of the first parameter of QString's arg() method is int. See https://doc.qt.io/qt-6/qstring.html#arg-3

1: https://bugs.gentoo.org/967015