### PR TITLE
Fix: update build instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 include .dev-config.mk
 
 .dev-config.mk:
-	[ ! -f .dev-config.mk ] && cp .dev-config.mk.default .dev-config.mk
+	[ ! -f .dev-config.mk ] && cp .dev-config.local.mk .dev-config.mk
 
 release:
 	mkdir -p build/Release

--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ Please, report any difficulties via [GitHub issues](https://github.com/cvut/qtrv
 - Qt 5 (minimal tested version is 5.9.5), experimental support of Qt 6
 - elfutils (optional; libelf works too but there can be some problems)
 
+Before building, initialize and update git submodules:
+
+```shell
+git submodule update --init --recursive
+```
+
 ### Quick Compilation on Linux
 
 On Linux, you can use a wrapper Makefile and run `make` in the project root directory. It will create a build directory
@@ -69,12 +75,11 @@ should invoke CMake directly.
 ### General Compilation
 
 ```shell
-cmake -DCMAKE_BUILD_TYPE=Release /path/to/qtrvsim
-make
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-O3 -march=native"
+make -C build
 ```
 
-Where `/path/to/qtrvsim` is path to this project root. The built binaries are to be found in the directory `target`in
-the build directory (the one, where cmake was called).
+The built binaries are to be found in the directory `target` in the build directory.
 
 `-DCMAKE_BUILD_TYPE=Debug` builds development version including sanitizers.
 
@@ -125,9 +130,9 @@ nix-env -if .
 Tests are managed by CTest (part of CMake). To build and run all tests, use this commands:
 
 ```bash
-cmake -DCMAKE_BUILD_TYPE=Release /path/to/QtRVSim
-make
-ctest
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-O3 -march=native"
+make -C build
+cd build && ctest
 ```
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ should invoke CMake directly.
 
 ```shell
 cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-O3 -march=native"
-make -C build
+make -C build # Or you can use all the available threads of your CPU by using make -C build -j $(nproc)
 ```
 
 The built binaries are to be found in the directory `target` in the build directory.
@@ -131,7 +131,7 @@ Tests are managed by CTest (part of CMake). To build and run all tests, use this
 
 ```bash
 cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-O3 -march=native"
-make -C build
+make -C build # Or you can use all the available threads of your CPU by using make -C build -j $(nproc)
 cd build && ctest
 ```
 


### PR DESCRIPTION
## Update build instructions and Makefile configuration

### Changes

- **README.md**: 
  - Added git submodule initialization step before building
  - Updated CMake command to use modern `-S . -B build` syntax
  - Added optimization flags (`-O3 -march=native`) to CMake build
  - Updated make command to use `-C build` for consistency
  - Updated Tests section with the new CMake syntax

- **Makefile**:
  - Renamed `.dev-config.mk.default` to `.dev-config.local.mk` to match the file on project's root.

### Rationale

The git submodule step is required for the build to succeed, and the updated CMake commands follow modern best practices while including performance optimizations.

